### PR TITLE
Remove sudo from instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ React component to listen to keydown and keyup keyboard events, defining and  di
 ### Install
 
 ```sh
-sudo npm i -S react-hot-keys
+npm i -S react-hot-keys
 ```
 
 ### Demo


### PR DESCRIPTION
`npm install` don't need sudo. Probably a typo there